### PR TITLE
Change systemd service file to be non-executable

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -124,7 +124,7 @@ when 'runit'
 when 'systemd'
   template '/etc/systemd/system/consul-template.service' do
     source 'consul-template-systemd.erb'
-    mode 0o755
+    mode 0o644
     variables(
       command: command,
       options: options


### PR DESCRIPTION
There's no reason for it to be, and systemd doesn't like it,
on Ubuntu 16.04.2 LTS at least:

dmesg:

systemd-sysv-generator[4385]: Configuration file
  /etc/systemd/system/consul-template.service is marked executable.
  Please remove executable permission bits. Proceeding anyway.